### PR TITLE
Add package version (v0.1.0)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -2,6 +2,7 @@ import Lake
 open Lake DSL
 
 package «lean-tcb» where
+  version := v!"0.1.0"
   leanOptions := #[
     ⟨`autoImplicit, false⟩
   ]


### PR DESCRIPTION
Adds `version := v!"0.1.0"` to lakefile.lean so Reservoir and Lake can track releases via git tags.

After merging, tag the release commit with `v0.1.0` — Lake's default `versionTags` pattern will pick it up automatically.